### PR TITLE
Add py35 classifier to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Utilities',
     ],
     description='Convert a set of dates into a compact list of globs',


### PR DESCRIPTION
Explicitly add the missing classifiers for python 3.5 work done in https://github.com/Yelp/dateglob/pull/5. This will fix false negatives for tools like [caniusepython3](https://github.com/brettcannon/caniusepython3).

There was no testing done, other than ensuring that a python wheel could be created.